### PR TITLE
Improve duration calculation with empty value checks

### DIFF
--- a/lib/Horde/Icalendar.php
+++ b/lib/Horde/Icalendar.php
@@ -1585,24 +1585,28 @@ class Horde_Icalendar
         }
 
         // Weeks.
-        $duration = 7 * 86400 * intval($durvalue[3]);
+        $duration = !empty($durvalue[3])
+            ? 7 * 86400 * intval($durvalue[3])
+            : 0;
 
-        if (count($durvalue) > 4) {
+        if (!empty($durvalue[4])) {
             // Days.
             $duration += 86400 * intval($durvalue[4]);
         }
 
-        if (count($durvalue) > 5) {
+        if (!empty($durvalue[5])) {
             // Hours.
-            $duration += 3600 * intval($durvalue[7]);
+            if (!empty($durvalue[7])) {
+                $duration += 3600 * intval($durvalue[7]);
+            }
 
             // Mins.
-            if (isset($durvalue[8])) {
+            if (!empty($durvalue[8])) {
                 $duration += 60 * intval($durvalue[8]);
             }
 
             // Secs.
-            if (isset($durvalue[9])) {
+            if (!empty($durvalue[9])) {
                 $duration += intval($durvalue[9]);
             }
         }


### PR DESCRIPTION
# Fix undefined array key warnings in `_parseDuration()`

## Summary

- Guard all regex capture groups in `_parseDuration()` with `!empty()` before reading them.
- Avoid PHP 8+ warnings when parsing RFC 5545 `DURATION` values that match the regex but omit the week capture group.

## Problem

`Horde_Icalendar::_parseDuration()` always reads `$durvalue[3]` (the week component) after a successful `preg_match()`. The pattern allows matches without a week segment, for example:

| Value   | Match | `$durvalue[3]` |
|---------|-------|----------------|
| `PT5M`  | yes   | empty string   |
| `PT0S`  | yes   | empty string   |
| `P`     | yes   | **unset**      |
| `PT`    | yes   | **unset**      |

On PHP 8+, accessing an unset capture group emits:

```
PHP ERROR: Undefined array key 3
```

This shows up when importing or processing iCalendar data with time-only or minimal `DURATION` properties (e.g. `TRIGGER;VALUE=DURATION:PT0S` on `VALARM` components).

## Solution

Only add each duration component when its capture group is non-empty:

```php
// Weeks.
$duration = !empty($durvalue[3])
    ? 7 * 86400 * intval($durvalue[3])
    : 0;

if (!empty($durvalue[4])) {
    $duration += 86400 * intval($durvalue[4]);
}

if (!empty($durvalue[5])) {
    if (!empty($durvalue[7])) {
        $duration += 3600 * intval($durvalue[7]);
    }
    if (!empty($durvalue[8])) {
        $duration += 60 * intval($durvalue[8]);
    }
    if (!empty($durvalue[9])) {
        $duration += intval($durvalue[9]);
    }
}
```

Behavior for well-formed durations (`P1W`, `P1D`, `PT5M`, `-P1DT1H30M15S`, etc.) is unchanged; invalid minimal forms like `P` / `PT` now yield `0` seconds without warnings.

## Test plan

- [ ] Run `vendor/horde/icalendar/test/Horde/Icalendar/ExportTest.php` — `testDuration0` and `testDuration8d_not_1w1d` pass.
- [ ] Import or open a calendar event with `DURATION:PT0S` or `TRIGGER;VALUE=DURATION:PT0S`; confirm no `Undefined array key 3` in Horde logs.
- [ ] Parse representative durations manually or via unit test: `P1W`, `P1D`, `PT5M`, `PT0S`, `-P1DT1H30M15S` — expected second counts unchanged from before.
